### PR TITLE
Fixed bp-chart outputting files with zero size

### DIFF
--- a/benchpress/visualizer/bar_per_cmd.py
+++ b/benchpress/visualizer/bar_per_cmd.py
@@ -88,7 +88,7 @@ def one_bar_per_cmd(args):
             else:
                 raise ValueError("--mpld3: The output must be either `html` or `json`")
         else:
-            pylab.savefig(args.output.name, format=fformat)
+            pylab.savefig(fname, format=fformat)
     else:
         if args.mpld3:
             import mpld3

--- a/benchpress/visualizer/bar_per_cmd.py
+++ b/benchpress/visualizer/bar_per_cmd.py
@@ -88,7 +88,7 @@ def one_bar_per_cmd(args):
             else:
                 raise ValueError("--mpld3: The output must be either `html` or `json`")
         else:
-            pylab.savefig(args.output, format=fformat)
+            pylab.savefig(args.output.name, format=fformat)
     else:
         if args.mpld3:
             import mpld3


### PR DESCRIPTION
bp-chart outputted files with zero size, this is due to pylab.savefig() not receiving a string for the name of the output file. 